### PR TITLE
resolving security vulnerability in Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ numpy==1.20.1
 packaging==20.3
 pandas==1.2.3
 pep517==0.8.2
-Pillow==8.1.0
+Pillow==8.1.2
 progress==1.5
 pyparsing==2.4.6
 python-dateutil==2.8.1


### PR DESCRIPTION
Moves the dependency to a version of Pillow that fixes https://nvd.nist.gov/vuln/detail/CVE-2021-27921 